### PR TITLE
Replace typed properties with doc-blocks (make compatible with php 7.2)

### DIFF
--- a/src/Here/Xyz/Common/XyzCredentials.php
+++ b/src/Here/Xyz/Common/XyzCredentials.php
@@ -4,7 +4,10 @@ namespace HiFolks\Milk\Here\Xyz\Common;
 
 class XyzCredentials
 {
-    private string $token;
+    /**
+     * @var string
+     */
+    private $token;
 
 
     /**

--- a/src/Here/Xyz/Space/XyzSpaceFeatureEditor.php
+++ b/src/Here/Xyz/Space/XyzSpaceFeatureEditor.php
@@ -13,9 +13,15 @@ use stdClass;
  */
 class XyzSpaceFeatureEditor extends XyzSpaceFeatureBase
 {
+    /**
+     * @var array
+     */
+    protected $paramAddTags = [];
 
-    protected array $paramAddTags = [];
-    protected array $paramRemoveTags = [];
+    /**
+     * @var array
+     */
+    protected $paramRemoveTags = [];
 
 
     public function __construct()

--- a/src/Here/Xyz/Space/XyzSpaceStatistics.php
+++ b/src/Here/Xyz/Space/XyzSpaceStatistics.php
@@ -11,9 +11,10 @@ use HiFolks\Milk\Here\Xyz\Common\XyzConfig;
  */
 class XyzSpaceStatistics extends XyzClient
 {
-
-
-    private bool $paramSkipCache = false;
+    /**
+     * @var bool
+     */
+    private $paramSkipCache = false;
 
 
 

--- a/src/Utils/GeoJson.php
+++ b/src/Utils/GeoJson.php
@@ -4,7 +4,10 @@ namespace HiFolks\Milk\Utils;
 
 class GeoJson
 {
-    private array $featureCollection = [];
+    /**
+     * @var array
+     */
+    private $featureCollection = [];
 
 
     public function addPoint($latitude, $longitude, $properties = null, $id = null)


### PR DESCRIPTION
Typed properties are available only in PHP 7.4+.

Closes #10 
Closes #11 
Closes #12 
Closes #13