### PR TITLE
add Environment class to safely read environment variables with a fallback

### DIFF
--- a/src/Utils/Environment.php
+++ b/src/Utils/Environment.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace HiFolks\Milk\Utils;
+
+class Environment
+{
+    /**
+     * Method to get environment variable via $_ENV
+     * If the env variable doesn't exist, it is returned $default set by the user.
+     * @param string $parameter
+     * @param string $default
+     * @return mixed|string
+     */
+    public static function getEnv(string  $parameter, $default = "")
+    {
+        return $_ENV[$parameter] ?? $default;
+    }
+}


### PR DESCRIPTION
### Here's what I did in this PR - (Issue #19 )

I added a new class named `Environment.php` in `src/Utils/` directory.

And inside that class I added a new method with following body. It accepts two parameters. First one is the environment variable we're requesting. Second one is the fallback default value. 

```
public static function getEnv(string  $parameter, $default = "")
{
    return $_ENV[$parameter] ?? $default;
}
```

We can call this method like this,

```
Environment::getEnv("HOST", "127.0.0.1");
```
Or

```
Environment::getEnv("HOST");
```

Second parameter is optional. Method will return a blank string if it cannot find the request environment variable. 

So, @roberto-butti , let me know what you think. This can further be improved of course. As I was researching the different between `$_ENV` and `dotenv`, I found that `dotenv `considers the variables in a case-sensitive manner. So, let me know if you wan that to be implemented here too. Thanks!