### PR TITLE
extend compatibility for guzzle, phpdotenv, phpunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,12 @@
     "require": {
         "php": "^7.2",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "^7.1",
+        "guzzlehttp/guzzle": "^6.3|^7.0",
         "jmikola/geojson": "^1.0",
-        "vlucas/phpdotenv": "^5.2"
+        "vlucas/phpdotenv": "^3.3|^4.0|^5.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0"
+        "phpunit/phpunit": "^7.5.15|^8.4|^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/examples/01_getspaces.php
+++ b/examples/01_getspaces.php
@@ -19,6 +19,7 @@ echo "GET" . PHP_EOL;
 $s = $space->get();
 if ($s->isError()) {
     echo "Error: " . $s->getErrorMessage();
+    $space->debug();
 } else {
     echo $space->getUrl();
     $space->debug();


### PR DESCRIPTION
"guzzlehttp/guzzle": "^6.3|^7.0",
"vlucas/phpdotenv": "^3.3|^4.0|^5.2"
"phpunit/phpunit": "^7.5.15|^8.4|^9.0"