### PR TITLE
Makefile for unit test, phpstan and phpcs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+phpunit:
+	vendor/bin/phpunit --coverage-text
+
+phpstan:
+	vendor/bin/phpstan analyse -c phpstan.neon
+
+phpcs:
+	phpcs --standard=PSR12 src


### PR DESCRIPTION
close #23 :detective: 

This pr create a **Makefile** in the root with three targets:

- phpunit
- phpstan
- phpcs

Both phpunit and phpstan use the binary from vendor. Your project does not contain the package **squizlabs/php_codesniffer** in the composer.json, so I put the same sample of the issue.